### PR TITLE
fix: accept Korean API key env for probe CLI

### DIFF
--- a/src/lawpy/probe/cli.py
+++ b/src/lawpy/probe/cli.py
@@ -12,10 +12,10 @@ from lawpy.probe.snapshot import SnapshotStore
 
 
 def _get_runner(api_key: str | None) -> ProbeRunner:
-    key = api_key or os.environ.get("LAWPY_API_KEY")
+    key = api_key or os.environ.get("LAWPY_KR_API_KEY") or os.environ.get("LAWPY_API_KEY")
     if not key:
         print(
-            "Error: API key required. Set LAWPY_API_KEY env var or use --api-key.",
+            "Error: API key required. Set LAWPY_KR_API_KEY or LAWPY_API_KEY env var, or use --api-key.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tests/test_probe_cli.py
+++ b/tests/test_probe_cli.py
@@ -1,0 +1,39 @@
+"""Tests for the lawpy-probe CLI."""
+
+from __future__ import annotations
+
+from lawpy.probe import cli
+
+
+def test_get_runner_accepts_kr_api_key_env(monkeypatch):
+    created = {}
+
+    class FakeRunner:
+        def __init__(self, api_key: str) -> None:
+            created["api_key"] = api_key
+
+    monkeypatch.delenv("LAWPY_API_KEY", raising=False)
+    monkeypatch.setenv("LAWPY_KR_API_KEY", "kr-secret")
+    monkeypatch.setattr(cli, "ProbeRunner", FakeRunner)
+
+    runner = cli._get_runner(None)
+
+    assert isinstance(runner, FakeRunner)
+    assert created["api_key"] == "kr-secret"
+
+
+def test_get_runner_prefers_explicit_api_key(monkeypatch):
+    created = {}
+
+    class FakeRunner:
+        def __init__(self, api_key: str) -> None:
+            created["api_key"] = api_key
+
+    monkeypatch.setenv("LAWPY_KR_API_KEY", "kr-secret")
+    monkeypatch.setenv("LAWPY_API_KEY", "generic-secret")
+    monkeypatch.setattr(cli, "ProbeRunner", FakeRunner)
+
+    runner = cli._get_runner("explicit-secret")
+
+    assert isinstance(runner, FakeRunner)
+    assert created["api_key"] == "explicit-secret"


### PR DESCRIPTION
## Summary
- let lawpy-probe read LAWPY_KR_API_KEY in addition to LAWPY_API_KEY
- add regression tests for API key resolution

## Context
The API drift workflow sets LAWPY_KR_API_KEY from the repository secret. The previous fix corrected JSON argument order, but the manual workflow run still produced an empty probe report because the CLI ignored LAWPY_KR_API_KEY.

## Test Plan
- uv run pytest tests/test_probe_cli.py tests/test_api_drift_workflow.py -q --no-cov
- uv run ruff check src/lawpy/probe/cli.py tests/test_probe_cli.py