### PR TITLE
fix: keep probe JSON output machine-readable

### DIFF
--- a/src/lawpy/probe/cli.py
+++ b/src/lawpy/probe/cli.py
@@ -90,16 +90,17 @@ def cmd_diff(names: list[str] | None, api_key: str | None, output_json: bool) ->
                 print(f"  ❌ Unknown probe: {n}", file=sys.stderr)
                 exit_code = 1
                 continue
-            print(f"  Checking {n}...", end=" ", flush=True)
+            progress_stream = sys.stderr if output_json else sys.stdout
+            print(f"  Checking {n}...", end=" ", flush=True, file=progress_stream)
             try:
                 run = runner.diff(n)
                 summary = run.diff.summary()
-                print(summary)
+                print(summary, file=progress_stream)
                 results.append(run.diff.to_dict())
                 if run.diff.has_breaking_changes:
                     exit_code = 1
             except Exception as e:
-                print(f"❌  {e}")
+                print(f"❌  {e}", file=progress_stream)
                 results.append({"name": n, "error": str(e), "status": "error"})
                 exit_code = 1
     finally:

--- a/tests/test_probe_cli.py
+++ b/tests/test_probe_cli.py
@@ -37,3 +37,28 @@ def test_get_runner_prefers_explicit_api_key(monkeypatch):
 
     assert isinstance(runner, FakeRunner)
     assert created["api_key"] == "explicit-secret"
+
+
+def test_cmd_diff_json_stdout_is_valid_json(monkeypatch, capsys):
+    from lawpy.probe.differ import DiffResult
+
+    class FakeRun:
+        diff = DiffResult(name="sample")
+
+    class FakeRunner:
+        def diff(self, name: str) -> FakeRun:
+            assert name == "sample"
+            return FakeRun()
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(cli, "_get_runner", lambda api_key: FakeRunner())
+    monkeypatch.setattr(cli, "CONFIGS_BY_NAME", {"sample": object()})
+
+    exit_code = cli.cmd_diff(["sample"], api_key="secret", output_json=True)
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.startswith("[\n")
+    assert "Checking sample" not in captured.out


### PR DESCRIPTION
## Summary
- send lawpy-probe diff progress/summary lines to stderr when --output json is used
- keep stdout parseable JSON for workflow artifacts
- add regression coverage for JSON stdout

## Test Plan
- uv run pytest tests/test_probe_cli.py tests/test_api_drift_workflow.py -q --no-cov
- uv run ruff check src/lawpy/probe/cli.py tests/test_probe_cli.py