### PR TITLE
feat(kr): add ConstitutionalDecisionClient for detc target

### DIFF
--- a/src/lawpy/kr/__init__.py
+++ b/src/lawpy/kr/__init__.py
@@ -1,7 +1,8 @@
 """Korean law API modules."""
 
 from lawpy.kr.client import KoreanLawClient
+from lawpy.kr.constitutional_decision import ConstitutionalDecisionClient
 from lawpy.kr.law import LawClient
 from lawpy.kr.precedent import PrecedentClient
 
-__all__ = ["KoreanLawClient", "LawClient", "PrecedentClient"]
+__all__ = ["KoreanLawClient", "LawClient", "PrecedentClient", "ConstitutionalDecisionClient"]

--- a/src/lawpy/kr/client.py
+++ b/src/lawpy/kr/client.py
@@ -1,10 +1,11 @@
 """Integrated client for Korean law APIs."""
 
+from lawpy.kr.constitutional_decision import ConstitutionalDecisionClient
 from lawpy.kr.law import LawClient
 from lawpy.kr.precedent import PrecedentClient
 
 
-class KoreanLawClient(LawClient, PrecedentClient):
+class KoreanLawClient(LawClient, PrecedentClient, ConstitutionalDecisionClient):
     """Integrated client for Korean National Law Information Center API.
 
     Provides a single entry-point for all implemented Korean law open-data APIs.
@@ -20,12 +21,15 @@ class KoreanLawClient(LawClient, PrecedentClient):
       - :meth:`search_precedents`      판례 목록 조회
       - :meth:`get_precedent_detail`   판례 본문 조회
 
+    **헌재결정례 (Constitutional Court Decisions) — implemented**:
+      - :meth:`search_decisions`       헌재결정례 목록 조회
+      - :meth:`get_decision_detail`    헌재결정례 본문 조회
+
     **향후 구현 예정**:
       - 행정규칙 (Administrative Rules)
       - 자치법규 (Autonomous Ordinances)
-      - 헌재결정례 (Constitutional Court Decisions)
-      - 법령해석례 (Legal Interpretation Cases)
       - 행정심판례 (Administrative Review Cases)
+      - 법령해석례 (Legal Interpretation Cases)
       - 위원회결정문 (Committee Decisions)
       - 조약 (Treaties)
       - 별표·서식 (Annexes and Forms)

--- a/src/lawpy/kr/constitutional_decision.py
+++ b/src/lawpy/kr/constitutional_decision.py
@@ -1,0 +1,213 @@
+"""Constitutional Court decision (헌재결정례) module for Korean law API."""
+
+import xmltodict
+
+from lawpy.exceptions import NotFoundError, ParseError
+from lawpy.kr.base import KoreanBaseClient
+from lawpy.models import ConstitutionalDecision, ConstitutionalDecisionDetail
+
+
+class ConstitutionalDecisionClient(KoreanBaseClient):
+    """Client for Constitutional Court Decision (헌재결정례) APIs.
+
+    Wraps the National Law Information Center's Constitutional Court decision
+    search and content-retrieval endpoints:
+      - List:   GET http://www.law.go.kr/DRF/lawSearch.do?target=detc
+      - Detail: GET http://www.law.go.kr/DRF/lawService.do?target=detc&ID=<id>
+    """
+
+    # ------------------------------------------------------------------ #
+    #  Public API                                                          #
+    # ------------------------------------------------------------------ #
+
+    def search_decisions(
+        self,
+        query: str | None = None,
+        search_scope: int = 1,
+        sort: str = "ddes",
+        page: int = 1,
+        per_page: int = 20,
+        case_gana: str | None = None,
+        final_date: str | None = None,
+        case_number: str | None = None,
+        output_type: str = "XML",
+    ) -> list[ConstitutionalDecision]:
+        """Search Constitutional Court decisions (헌재결정례 목록 조회).
+
+        Args:
+            query: Search keyword. When *search_scope=2* performs full-text search.
+            search_scope: 1 = decision name (default), 2 = full-text.
+            sort: Sort order.
+                'lasc'  사건명 오름차순
+                'ldes'  사건명 내림차순
+                'dasc'  종국일자 오름차순
+                'ddes'  종국일자 내림차순 (default)
+                'nasc'  사건번호 오름차순
+                'ndes'  사건번호 내림차순
+                'efasc' 종국일자 오름차순
+                'efdes' 종국일자 내림차순
+            page: Page number (default 1).
+            per_page: Results per page (default 20, max 100).
+            case_gana: Alphabetical case prefix (사전식 검색, e.g. 'ga').
+            final_date: Final decision date filter (종국일자, YYYYMMDD).
+            case_number: Case number filter (사건번호).
+            output_type: 'XML' or 'JSON'.
+
+        Returns:
+            List of :class:`ConstitutionalDecision` objects.
+
+        Raises:
+            APIError: If the HTTP request fails.
+            ParseError: If the response cannot be parsed.
+        """
+        params: dict[str, str | int] = {
+            "OC": str(self.api_key),
+            "target": "detc",
+            "type": output_type,
+            "search": search_scope,
+            "sort": sort,
+            "display": per_page,
+            "page": page,
+        }
+
+        if query is not None:
+            params["query"] = query
+        if case_gana is not None:
+            params["gana"] = case_gana
+        if final_date is not None:
+            params["date"] = final_date
+        if case_number is not None:
+            params["nb"] = case_number
+
+        response = self._make_request(self.BASE_URL, params)
+        return self._parse_decision_list(response.content)
+
+    def get_decision_detail(
+        self,
+        decision_id: str,
+        output_type: str = "XML",
+    ) -> ConstitutionalDecisionDetail:
+        """Get full text of a Constitutional Court decision (헌재결정례 본문 조회).
+
+        Args:
+            decision_id: Decision serial number (헌재결정례일련번호) from
+                :meth:`search_decisions`.
+            output_type: 'XML' or 'JSON'.
+
+        Returns:
+            :class:`ConstitutionalDecisionDetail` with full decision text.
+
+        Raises:
+            NotFoundError: If the decision is not found.
+            APIError: If the HTTP request fails.
+            ParseError: If the response cannot be parsed.
+        """
+        params: dict[str, str | int] = {
+            "OC": str(self.api_key),
+            "target": "detc",
+            "type": output_type,
+            "ID": decision_id,
+        }
+
+        response = self._make_request(self.SERVICE_URL, params, raise_404=True)
+        return self._parse_decision_detail(response.content, decision_id)
+
+    # ------------------------------------------------------------------ #
+    #  Private helpers                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _parse_decision_list(self, content: bytes) -> list[ConstitutionalDecision]:
+        """Parse decision list from XML response.
+
+        Args:
+            content: Raw XML bytes from ``lawSearch.do?target=detc``.
+
+        Returns:
+            List of :class:`ConstitutionalDecision` objects.
+
+        Raises:
+            ParseError: If parsing fails.
+        """
+        try:
+            data = xmltodict.parse(content)
+        except Exception as e:
+            raise ParseError(f"Failed to parse XML: {e}") from e
+
+        detc_search = data.get("DetcSearch") or data.get("LawSearch")
+        if not detc_search:
+            return []
+
+        items = detc_search.get("detc", [])
+        if items is None:
+            return []
+        if not isinstance(items, list):
+            items = [items]
+
+        decisions: list[ConstitutionalDecision] = []
+        for item in items:
+            try:
+                decisions.append(
+                    ConstitutionalDecision(
+                        decision_id=str(item.get("헌재결정례일련번호", "")),
+                        case_name=item.get("사건명", ""),
+                        case_number=item.get("사건번호", ""),
+                        final_date=item.get("종국일자"),
+                        # The spec lists this field as '헌재결정례 상세링크';
+                        # XML tags cannot contain spaces so we also try the
+                        # concatenated form used by similar endpoints.
+                        detail_link=(
+                            item.get("헌재결정례상세링크")
+                            or item.get("헌재결정례 상세링크")
+                        ),
+                    )
+                )
+            except Exception as e:
+                raise ParseError(f"Failed to parse decision item: {e}") from e
+
+        return decisions
+
+    def _parse_decision_detail(
+        self, content: bytes, decision_id: str
+    ) -> ConstitutionalDecisionDetail:
+        """Parse decision detail from XML response.
+
+        Args:
+            content: Raw XML bytes from ``lawService.do?target=detc``.
+            decision_id: The requested decision ID (used as fallback).
+
+        Returns:
+            :class:`ConstitutionalDecisionDetail` object.
+
+        Raises:
+            NotFoundError: If the API signals the record was not found.
+            ParseError: If parsing fails.
+        """
+        try:
+            data = xmltodict.parse(content)
+        except Exception as e:
+            raise ParseError(f"Failed to parse XML: {e}") from e
+
+        detc_data: dict = (
+            data.get("DetcService")
+            or data.get("헌재결정례")
+            or {}
+        )
+
+        if not detc_data:
+            raise NotFoundError(
+                f"Constitutional Court decision not found: {decision_id}",
+                status_code=404,
+            )
+
+        return ConstitutionalDecisionDetail(
+            decision_id=str(detc_data.get("헌재결정례일련번호") or decision_id),
+            case_name=detc_data.get("사건명", ""),
+            case_number=detc_data.get("사건번호", ""),
+            final_date=detc_data.get("종국일자"),
+            case_type=detc_data.get("사건종류"),
+            decision_type=detc_data.get("결정유형"),
+            ref_statutes=detc_data.get("참조조문"),
+            ruling_summary=detc_data.get("판시사항"),
+            decision_gist=detc_data.get("결정요지"),
+            full_text=detc_data.get("결정내용"),
+        )

--- a/src/lawpy/models.py
+++ b/src/lawpy/models.py
@@ -101,3 +101,28 @@ class LawText(BaseModel):
     law_id: str
     law_name: str
     articles: list[dict]
+
+
+class ConstitutionalDecision(BaseModel):
+    """Constitutional Court decision (헌재결정례) list item."""
+
+    decision_id: str = Field(description="Decision serial number (헌재결정례일련번호)")
+    case_name: str = Field(description="Case name (사건명)")
+    case_number: str = Field(description="Case number (사건번호)")
+    final_date: str | None = Field(default=None, description="Final decision date YYYYMMDD (종국일자)")
+    detail_link: str | None = Field(default=None, description="URL link to full decision (헌재결정례상세링크)")
+
+
+class ConstitutionalDecisionDetail(BaseModel):
+    """Constitutional Court decision (헌재결정례) with full text."""
+
+    decision_id: str = Field(description="Decision serial number (헌재결정례일련번호)")
+    case_name: str = Field(description="Case name (사건명)")
+    case_number: str = Field(description="Case number (사건번호)")
+    final_date: str | None = Field(default=None, description="Final decision date YYYYMMDD (종국일자)")
+    case_type: str | None = Field(default=None, description="Case type (사건종류)")
+    decision_type: str | None = Field(default=None, description="Decision type (결정유형, e.g. 인용/기각/각하)")
+    ref_statutes: str | None = Field(default=None, description="Referenced statutes (참조조문)")
+    ruling_summary: str | None = Field(default=None, description="Ruling summary (판시사항)")
+    decision_gist: str | None = Field(default=None, description="Decision gist (결정요지)")
+    full_text: str | None = Field(default=None, description="Full text of the decision (결정내용)")

--- a/tests/test_kr_constitutional_decision.py
+++ b/tests/test_kr_constitutional_decision.py
@@ -1,0 +1,254 @@
+"""Tests for Korean Constitutional Court decision (헌재결정례) client."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from lawpy.exceptions import APIError, NotFoundError, ParseError
+from lawpy.kr import KoreanLawClient
+
+
+@pytest.fixture
+def client() -> KoreanLawClient:
+    """Create a test client."""
+    return KoreanLawClient(api_key="test_key")
+
+
+# ---------------------------------------------------------------------------
+# Helper XML fixtures
+# ---------------------------------------------------------------------------
+
+DETC_LIST_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<DetcSearch>
+    <detc id="1">
+        <헌재결정례일련번호>10001</헌재결정례일련번호>
+        <사건명><![CDATA[위헌소원]]></사건명>
+        <사건번호>2020헌바123</사건번호>
+        <종국일자>20201015</종국일자>
+        <헌재결정례상세링크>https://www.law.go.kr/LSW/detcInfoP.do?detcSeq=10001</헌재결정례상세링크>
+    </detc>
+    <detc id="2">
+        <헌재결정례일련번호>10002</헌재결정례일련번호>
+        <사건명><![CDATA[헌법소원심판]]></사건명>
+        <사건번호>2021헌마456</사건번호>
+        <종국일자>20211201</종국일자>
+        <헌재결정례상세링크>https://www.law.go.kr/LSW/detcInfoP.do?detcSeq=10002</헌재결정례상세링크>
+    </detc>
+</DetcSearch>""".encode()
+
+DETC_LIST_EMPTY_XML = b"""<?xml version="1.0" encoding="UTF-8"?><DetcSearch/>"""
+
+DETC_SINGLE_LIST_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<DetcSearch>
+    <detc id="1">
+        <헌재결정례일련번호>10001</헌재결정례일련번호>
+        <사건명><![CDATA[위헌소원]]></사건명>
+        <사건번호>2020헌바123</사건번호>
+    </detc>
+</DetcSearch>""".encode()
+
+DETC_DETAIL_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<DetcService>
+    <헌재결정례일련번호>10001</헌재결정례일련번호>
+    <사건명><![CDATA[위헌소원]]></사건명>
+    <사건번호>2020헌바123</사건번호>
+    <종국일자>20201015</종국일자>
+    <사건종류>헌법소원</사건종류>
+    <결정유형>인용</결정유형>
+    <참조조문>헌법 제12조, 형사소송법 제244조</참조조문>
+    <판시사항>피의자 진술거부권 고지 의무의 범위</판시사항>
+    <결정요지>수사기관은 피의자에게 진술거부권을 고지할 의무가 있다.</결정요지>
+    <결정내용>【주문】 이 사건 헌법소원심판 청구를 인용한다. 【이유】 살피건대...</결정내용>
+</DetcService>""".encode()
+
+
+# ---------------------------------------------------------------------------
+# Test: search_decisions
+# ---------------------------------------------------------------------------
+
+
+class TestSearchDecisions:
+    """Tests for ConstitutionalDecisionClient.search_decisions."""
+
+    def test_search_returns_list(self, client: KoreanLawClient) -> None:
+        """Parsing a two-item list returns two ConstitutionalDecision objects."""
+        mock_resp = Mock()
+        mock_resp.content = DETC_LIST_XML
+
+        with patch.object(client._client, "get", return_value=mock_resp):
+            results = client.search_decisions(query="위헌")
+
+        assert len(results) == 2
+
+    def test_search_fields_mapped_correctly(self, client: KoreanLawClient) -> None:
+        """All list fields are mapped onto the ConstitutionalDecision model."""
+        mock_resp = Mock()
+        mock_resp.content = DETC_LIST_XML
+
+        with patch.object(client._client, "get", return_value=mock_resp):
+            results = client.search_decisions()
+
+        first = results[0]
+        assert first.decision_id == "10001"
+        assert first.case_name == "위헌소원"
+        assert first.case_number == "2020헌바123"
+        assert first.final_date == "20201015"
+        assert first.detail_link is not None and "10001" in first.detail_link
+
+    def test_search_empty_result(self, client: KoreanLawClient) -> None:
+        """Empty DetcSearch element returns an empty list."""
+        mock_resp = Mock()
+        mock_resp.content = DETC_LIST_EMPTY_XML
+
+        with patch.object(client._client, "get", return_value=mock_resp):
+            results = client.search_decisions(query="없는결정")
+
+        assert results == []
+
+    def test_search_single_item_not_wrapped_in_list(self, client: KoreanLawClient) -> None:
+        """xmltodict returns a dict (not list) for single items — still works."""
+        mock_resp = Mock()
+        mock_resp.content = DETC_SINGLE_LIST_XML
+
+        with patch.object(client._client, "get", return_value=mock_resp):
+            results = client.search_decisions()
+
+        assert len(results) == 1
+        assert results[0].decision_id == "10001"
+
+    def test_search_with_optional_params_sent(self, client: KoreanLawClient) -> None:
+        """Optional filtering params are forwarded to the HTTP call."""
+        mock_resp = Mock()
+        mock_resp.content = DETC_LIST_EMPTY_XML
+        mock_get = Mock(return_value=mock_resp)
+
+        with patch.object(client._client, "get", mock_get):
+            client.search_decisions(
+                query="헌법",
+                search_scope=2,
+                sort="efdes",
+                page=2,
+                per_page=50,
+                case_gana="ga",
+                final_date="20201015",
+                case_number="2020헌바123",
+            )
+
+        call_kwargs = mock_get.call_args
+        params = call_kwargs[1]["params"] if call_kwargs[1] else call_kwargs[0][1]
+        assert params["query"] == "헌법"
+        assert params["search"] == 2
+        assert params["sort"] == "efdes"
+        assert params["page"] == 2
+        assert params["display"] == 50
+        assert params["gana"] == "ga"
+        assert params["date"] == "20201015"
+        assert params["nb"] == "2020헌바123"
+        assert params["target"] == "detc"
+
+    def test_search_api_error(self, client: KoreanLawClient) -> None:
+        """HTTP 500 is wrapped in APIError."""
+        from httpx import HTTPStatusError
+
+        mock_resp = Mock()
+        mock_resp.status_code = 500
+        err = HTTPStatusError("Server error", request=Mock(), response=mock_resp)
+
+        with patch.object(client._client, "get", side_effect=err):
+            with pytest.raises(APIError) as exc_info:
+                client.search_decisions(query="헌법")
+
+        assert "HTTP error: 500" in str(exc_info.value)
+
+    def test_search_invalid_xml_raises_parse_error(self, client: KoreanLawClient) -> None:
+        """Malformed XML raises ParseError."""
+        mock_resp = Mock()
+        mock_resp.content = b"this is not xml at all <<<>>>"
+
+        with patch.object(client._client, "get", return_value=mock_resp):
+            with pytest.raises(ParseError):
+                client.search_decisions()
+
+
+# ---------------------------------------------------------------------------
+# Test: get_decision_detail
+# ---------------------------------------------------------------------------
+
+
+class TestGetDecisionDetail:
+    """Tests for ConstitutionalDecisionClient.get_decision_detail."""
+
+    def test_detail_fields_mapped_correctly(self, client: KoreanLawClient) -> None:
+        """All detail fields are mapped onto ConstitutionalDecisionDetail."""
+        mock_resp = Mock()
+        mock_resp.content = DETC_DETAIL_XML
+
+        with patch.object(client._client, "get", return_value=mock_resp):
+            detail = client.get_decision_detail("10001")
+
+        assert detail.decision_id == "10001"
+        assert detail.case_name == "위헌소원"
+        assert detail.case_number == "2020헌바123"
+        assert detail.final_date == "20201015"
+        assert detail.case_type == "헌법소원"
+        assert detail.decision_type == "인용"
+        assert detail.ref_statutes is not None and "헌법 제12조" in detail.ref_statutes
+        assert detail.ruling_summary == "피의자 진술거부권 고지 의무의 범위"
+        assert detail.decision_gist is not None and "진술거부권" in detail.decision_gist
+        assert detail.full_text is not None and "인용" in detail.full_text
+
+    def test_detail_id_param_sent(self, client: KoreanLawClient) -> None:
+        """The ID parameter is forwarded correctly."""
+        mock_resp = Mock()
+        mock_resp.content = DETC_DETAIL_XML
+        mock_get = Mock(return_value=mock_resp)
+
+        with patch.object(client._client, "get", mock_get):
+            client.get_decision_detail("99999")
+
+        call_kwargs = mock_get.call_args
+        params = call_kwargs[1]["params"] if call_kwargs[1] else call_kwargs[0][1]
+        assert params["ID"] == "99999"
+        assert params["target"] == "detc"
+
+    def test_detail_not_found(self, client: KoreanLawClient) -> None:
+        """HTTP 404 raises NotFoundError."""
+        from httpx import HTTPStatusError
+
+        mock_resp = Mock()
+        mock_resp.status_code = 404
+        err = HTTPStatusError("Not found", request=Mock(), response=mock_resp)
+
+        with patch.object(client._client, "get", side_effect=err):
+            with pytest.raises(NotFoundError):
+                client.get_decision_detail("000000")
+
+    def test_detail_api_error(self, client: KoreanLawClient) -> None:
+        """HTTP 500 raises APIError."""
+        from httpx import HTTPStatusError
+
+        mock_resp = Mock()
+        mock_resp.status_code = 500
+        err = HTTPStatusError("Server error", request=Mock(), response=mock_resp)
+
+        with patch.object(client._client, "get", side_effect=err):
+            with pytest.raises(APIError):
+                client.get_decision_detail("10001")
+
+    def test_detail_empty_root_raises_not_found(self, client: KoreanLawClient) -> None:
+        """A response with an unrecognised root element raises NotFoundError."""
+        mock_resp = Mock()
+        mock_resp.content = b"""<?xml version="1.0"?><UnknownRoot/>"""
+
+        with patch.object(client._client, "get", return_value=mock_resp):
+            with pytest.raises(NotFoundError):
+                client.get_decision_detail("99999")
+
+    def test_detail_invalid_xml_raises_parse_error(self, client: KoreanLawClient) -> None:
+        """Malformed XML raises ParseError."""
+        mock_resp = Mock()
+        mock_resp.content = b"<broken xml <<<"
+
+        with patch.object(client._client, "get", return_value=mock_resp):
+            with pytest.raises(ParseError):
+                client.get_decision_detail("10001")


### PR DESCRIPTION
Closes #2

This PR implements a hand-written XML parser for Constitutional Court decisions (헌재결정례), which is the first item in `.agent/TASKS.md`'s high-priority backlog.

**What's added**

- `src/lawpy/kr/constitutional_decision.py` — `ConstitutionalDecisionClient` with `search_decisions()` and `get_decision_detail()`, modelled closely on `precedent.py`
- `src/lawpy/models.py` — two new Pydantic models: `ConstitutionalDecision` (list item) and `ConstitutionalDecisionDetail` (full text)
- `src/lawpy/kr/client.py` — `KoreanLawClient` now includes `ConstitutionalDecisionClient` in its MRO
- `src/lawpy/kr/__init__.py` — exports `ConstitutionalDecisionClient`
- `tests/test_kr_constitutional_decision.py` — 13 unit tests mirroring `test_kr_precedent.py` structure (list parsing, field mapping, single-item dict edge case, optional params, error paths)

**A few things I'm uncertain about**

The detail response spec (`detcInfoGuide.json`) has an empty `response` field, so I inferred the XML root element as `DetcService` by analogy with `PrecService`. I've also added a `data.get("헌재결정례")` fallback in case the live API uses a different root. The detail_link field name in the list spec includes a space (`헌재결정례 상세링크`), which isn't valid in an XML tag, so I tried the no-space form first with the spaced form as a fallback. If I got either wrong, they should be easy to correct once tested against the real endpoint.

The `search_decisions` default sort is `ddes` (most recent first) by analogy with `search_precedents`, but the spec also lists `efdes` (종국일자 내림차순) — either would be reasonable. Happy to change it if you have a preference.

**Testing**

```
uv run pytest tests/test_kr_constitutional_decision.py -v
```

All 13 tests pass against the mocked responses. Live endpoint testing requires `LAWPY_KR_API_KEY`.

If this direction doesn't fit the way you'd planned to implement the `detc` parser, no problem at all — I'm happy to close this and let you take a different approach.

---

*This contribution was developed with AI assistance (Claude). The implementation logic and test cases were derived from the existing `precedent.py` patterns in this repository.*