### PR TITLE
docs: add installed help guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ pip install lawpy
 
 ## Quick Start
 
+### Installed help
+
+If you installed `lawpy` without cloning the repository, start here:
+
+```python
+import lawpy
+
+print(lawpy.help())
+print(lawpy.help("kr"))
+print(lawpy.help("generated"))
+```
+
+The same guide is available from the shell:
+
+```bash
+python -m lawpy.help kr
+```
+
 ### Korean Law API
 
 Set your API key (email ID) as an environment variable:
@@ -36,6 +54,10 @@ client = KoreanLawClient()
 # Or pass api_key directly
 client = KoreanLawClient(api_key="your-api-key")
 ```
+
+`KoreanLawClient` is the main ergonomic object for Korean law.go.kr data. It
+combines the public wrappers for laws, precedents, administrative rules,
+notices, local ordinances, and local notices.
 
 #### Search for laws
 
@@ -101,6 +123,31 @@ for h in history:
 history_detail = client.get_law_history_detail(mst=9094)
 print(history_detail)  # Returns HTML text
 ```
+
+### Generated-only targets
+
+KR v1 includes full generated coverage for the public spec inventory. If a
+target does not have a public wrapper on `KoreanLawClient` yet, import the
+generated client directly:
+
+```python
+from lawpy.kr.generated.trty import GeneratedTrtyClient
+
+client = GeneratedTrtyClient(api_key="your-api-key")
+treaties = client.search_trtys(query="FTA", display=10, page=1)
+row = treaties[0].model_dump(by_alias=True)
+```
+
+See [docs/ai-usage.md](docs/ai-usage.md) and
+[docs/kr/generated-coverage.md](docs/kr/generated-coverage.md) for the installed
+help pattern and the generated target matrix.
+
+## Specs and codegen policy
+
+The Korean specs, code generator, generated clients, generated models, and
+generated tests are public. The project treats reproducible generation, coverage
+documentation, and CI as the maintenance contract rather than hiding source
+specs.
 
 ## API Key
 

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -1,0 +1,101 @@
+# lawpy AI Usage Guide
+
+This guide is written for AI agents and automation code that need to use
+`lawpy` after installing it with `uv add lawpy` or `pip install lawpy`.
+
+## Installed Help
+
+The package includes an installed help surface:
+
+```python
+import lawpy
+
+print(lawpy.help())
+print(lawpy.help("kr"))
+print(lawpy.help("generated"))
+print(lawpy.help("codegen"))
+```
+
+It is also available as:
+
+```bash
+python -m lawpy.help
+python -m lawpy.help kr
+python -m lawpy.help generated
+python -m lawpy.help codegen
+```
+
+## Main Object
+
+Use `KoreanLawClient` first.
+
+```python
+from lawpy import KoreanLawClient
+
+client = KoreanLawClient(api_key="your-open-law-email-id")
+```
+
+`KoreanLawClient` is the ergonomic public surface for Korean law.go.kr data. It
+combines the implemented public wrappers for:
+
+- laws
+- precedents
+- administrative rules and notices
+- local ordinances and local notices
+
+## One Pattern
+
+Search returns a list. Detail methods fetch one full record.
+
+```python
+laws = client.search_laws("민법", per_page=5)
+detail = client.get_law_detail(law_id=laws[0].law_id)
+```
+
+The same pattern applies to other public wrappers:
+
+```python
+precedents = client.search_precedents("손해배상", per_page=5)
+precedent = client.get_precedent_detail(case_id=precedents[0].case_id)
+
+rules = client.search_administrative_rules("개인정보", per_page=5)
+rule = client.get_administrative_rule_detail(rule_id=rules[0].행정규칙ID)
+
+ordinances = client.search_ordinances("서울", per_page=5)
+ordinance = client.get_ordinance_detail(ordinance_id=ordinances[0].자치법규ID)
+```
+
+## Generated-Only Targets
+
+If `KoreanLawClient` does not expose a public wrapper for the target, import the
+generated client directly:
+
+```python
+from lawpy.kr.generated.trty import GeneratedTrtyClient
+
+client = GeneratedTrtyClient(api_key="your-open-law-email-id")
+treaties = client.search_trtys(query="FTA", display=10, page=1)
+row = treaties[0].model_dump(by_alias=True)
+```
+
+Naming pattern:
+
+- target file: `lawpy.kr.generated.{target}`
+- client class: `Generated{Target.capitalize()}Client`
+- search method: `search_{target}s(...)`
+- detail method: `get_{target}_detail(...)`
+
+For the complete generated target matrix, see
+[`docs/kr/generated-coverage.md`](kr/generated-coverage.md).
+
+## Codegen And Specs
+
+The Korean specs, code generator, generated clients, generated models, and
+generated tests are public.
+
+Support contract:
+
+- Prefer `KoreanLawClient` for stable public workflows.
+- Use generated clients for covered targets without a wrapper.
+- Generated output is reviewed through deterministic diffs, coverage docs, and CI.
+- Raw scraped specs may reflect upstream documentation quirks.

--- a/src/lawpy/__init__.py
+++ b/src/lawpy/__init__.py
@@ -1,3 +1,19 @@
+"""Universal law information API client library.
+
+Installed quickstart:
+    import lawpy
+    print(lawpy.help())
+
+Main Korean API object:
+    from lawpy import KoreanLawClient
+
+    client = KoreanLawClient(api_key="your-open-law-email-id")
+    laws = client.search_laws("민법", per_page=5)
+
+Use lawpy.help("kr") for public wrapper methods and
+lawpy.help("generated") for generated-only KR targets.
+"""
+
 from lawpy.kr import AdministrativeRuleClient, KoreanLawClient, OrdinanceClient, PrecedentClient
 from lawpy.kr.generated._models_generated import AdmrulDetail, AdmrulList, OrdinDetail, OrdinList
 from lawpy.models import (
@@ -12,6 +28,22 @@ from lawpy.models import (
 )
 
 __version__ = "0.1.0"
+
+
+def help(topic: str = "quickstart") -> str:
+    """Return installed lawpy usage guidance."""
+    from lawpy.help import guide
+
+    return guide(topic)
+
+
+def print_guide(topic: str = "quickstart") -> None:
+    """Print installed lawpy usage guidance."""
+    from lawpy.help import print_guide as _print_guide
+
+    _print_guide(topic)
+
+
 __all__ = [
     "AdministrativeRuleClient",
     "AdmrulDetail",
@@ -29,5 +61,7 @@ __all__ = [
     "Precedent",
     "PrecedentDetail",
     "SubItem",
+    "help",
+    "print_guide",
     "__version__",
 ]

--- a/src/lawpy/help.py
+++ b/src/lawpy/help.py
@@ -1,0 +1,193 @@
+"""Installed help surface for humans and AI agents using lawpy.
+
+This module is intentionally importable from an installed wheel. It gives a
+short, stable route from `uv add lawpy` to the objects and patterns that matter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import types
+from textwrap import dedent
+
+TOPICS = ("quickstart", "kr", "generated", "codegen")
+
+QUICKSTART = dedent(
+    """
+    lawpy quickstart
+    =================
+
+    Main object:
+        KoreanLawClient
+
+    Meaning:
+        KoreanLawClient is the ergonomic entry point for Korean law.go.kr data.
+        It combines the public wrappers for law, precedent, administrative rule,
+        and local ordinance workflows.
+
+    Basic pattern:
+        from lawpy import KoreanLawClient
+
+        client = KoreanLawClient(api_key="your-open-law-email-id")
+        results = client.search_laws("민법", per_page=5)
+        detail = client.get_law_detail(law_id=results[0].law_id)
+
+    API key:
+        Set LAWPY_KR_API_KEY, or pass api_key directly.
+        The key is the email username registered at open.law.go.kr.
+
+    Next:
+        lawpy.help("kr")         public wrapper method map
+        lawpy.help("generated")  use a generated-only target
+        lawpy.help("codegen")    specs/codegen support policy
+    """
+).strip()
+
+KR = dedent(
+    """
+    KoreanLawClient pattern
+    =======================
+
+    Use KoreanLawClient first. It is the stable public surface for common
+    datapan-data workflows.
+
+    Public wrapper methods:
+        Law:
+            search_laws(query, page=1, per_page=20)
+            get_law_detail(law_id=None, mst=None, article_number=None)
+            get_law_list(page=1, per_page=20)
+            get_law_history(query=None, page=1, per_page=20)
+
+        Precedent:
+            search_precedents(query=None, page=1, per_page=20)
+            get_precedent_detail(case_id=None, mst=None)
+
+        Administrative rules and notices:
+            search_administrative_rules(query=None, page=1, per_page=20)
+            search_notices(query=None, page=1, per_page=20)
+            get_administrative_rule_detail(rule_id=None, rule_name=None)
+
+        Local ordinances and local notices:
+            search_ordinances(query=None, page=1, per_page=20)
+            search_local_notices(query=None, page=1, per_page=20)
+            get_ordinance_detail(ordinance_id=None, mst=None)
+
+    One pattern teaches the rest:
+        items = client.search_ordinances("서울", per_page=10)
+        first = items[0]
+        detail = client.get_ordinance_detail(ordinance_id=first.자치법규ID)
+
+    Response pattern:
+        Public wrappers return typed Python objects or generated Pydantic models.
+        For generated Pydantic models, use model_dump(by_alias=True) when storing
+        the original Korean API field names.
+    """
+).strip()
+
+GENERATED = dedent(
+    """
+    Generated-only target pattern
+    =============================
+
+    If KoreanLawClient does not expose a public wrapper yet, import the generated
+    client directly from lawpy.kr.generated.<target>.
+
+    Example:
+        from lawpy.kr.generated.trty import GeneratedTrtyClient
+
+        client = GeneratedTrtyClient(api_key="your-open-law-email-id")
+        treaties = client.search_trtys(query="FTA", display=10, page=1)
+
+        row = treaties[0]
+        data = row.model_dump(by_alias=True)
+
+    Naming pattern:
+        target file:      src/lawpy/kr/generated/{target}.py
+        client class:     Generated{Target.capitalize()}Client
+        search method:    search_{target}s(...)
+        detail method:    get_{target}_detail(...)
+
+    Coverage:
+        KR v1 generated coverage includes 195 spec files, 89 generated modules,
+        and 89 generated tests. See docs/kr/generated-coverage.md in the source
+        repository for the full target/method matrix.
+    """
+).strip()
+
+CODEGEN = dedent(
+    """
+    Specs and codegen policy
+    ========================
+
+    lawpy keeps the Korean specs, code generator, generated clients, generated
+    models, and generated tests public.
+
+    Support contract:
+        - Prefer KoreanLawClient for stable public workflows.
+        - Use generated clients for covered targets without a wrapper.
+        - Generated code is reviewed through deterministic diffs, coverage docs,
+          and CI tests.
+        - Raw scraped specs may reflect upstream documentation quirks; generated
+          tests and live drift checks are the guardrails.
+
+    Contributor rule:
+        Change specs/codegen/generated output together. A generated target is not
+        complete unless its client, model surface, and generated test are aligned.
+    """
+).strip()
+
+_GUIDES = {
+    "quickstart": QUICKSTART,
+    "kr": KR,
+    "generated": GENERATED,
+    "codegen": CODEGEN,
+}
+
+
+def guide(topic: str = "quickstart") -> str:
+    """Return an installed lawpy usage guide.
+
+    Args:
+        topic: One of "quickstart", "kr", "generated", or "codegen".
+
+    Returns:
+        A plain-text guide suitable for `print()`, `help(lawpy)`, or AI agents.
+    """
+    normalized = topic.strip().lower()
+    if normalized not in _GUIDES:
+        choices = ", ".join(TOPICS)
+        msg = f"Unknown lawpy help topic {topic!r}. Expected one of: {choices}."
+        raise ValueError(msg)
+    return _GUIDES[normalized]
+
+
+def print_guide(topic: str = "quickstart") -> None:
+    """Print an installed lawpy usage guide."""
+    print(guide(topic))
+
+
+def main() -> None:
+    """CLI entry point for `python -m lawpy.help`."""
+    parser = argparse.ArgumentParser(description="Show installed lawpy usage guidance.")
+    parser.add_argument(
+        "topic",
+        nargs="?",
+        default="quickstart",
+        choices=TOPICS,
+        help="Guide topic to print.",
+    )
+    args = parser.parse_args()
+    print_guide(args.topic)
+
+
+class _HelpModule(types.ModuleType):
+    def __call__(self, topic: str = "quickstart") -> str:
+        return guide(topic)
+
+
+sys.modules[__name__].__class__ = _HelpModule
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lawpy/kr/__init__.py
+++ b/src/lawpy/kr/__init__.py
@@ -1,4 +1,17 @@
-"""Korean law API modules."""
+"""Korean law API modules.
+
+Start with KoreanLawClient for normal use:
+
+    from lawpy import KoreanLawClient
+
+    client = KoreanLawClient(api_key="your-open-law-email-id")
+    laws = client.search_laws("민법", per_page=5)
+
+For installed guidance, run:
+
+    import lawpy
+    print(lawpy.help("kr"))
+"""
 
 from lawpy.kr.administrative_rule import AdministrativeRuleClient
 from lawpy.kr.client import KoreanLawClient

--- a/src/lawpy/kr/client.py
+++ b/src/lawpy/kr/client.py
@@ -10,6 +10,17 @@ class KoreanLawClient(LawClient, PrecedentClient, AdministrativeRuleClient, Ordi
     """Integrated client for Korean National Law Information Center API.
 
     Provides a single entry-point for all implemented Korean law open-data APIs.
+    This is the object most users and AI agents should try first.
+
+    Basic pattern:
+      >>> from lawpy import KoreanLawClient
+      >>> client = KoreanLawClient(api_key="your-open-law-email-id")
+      >>> laws = client.search_laws("민법", per_page=5)
+      >>> detail = client.get_law_detail(law_id=laws[0].law_id)
+
+    If a target is not exposed here yet, use the generated client under
+    ``lawpy.kr.generated.<target>``. Run ``import lawpy; print(lawpy.help())``
+    for installed guidance.
 
     **법령 (Law) — implemented**:
       - :meth:`search_laws`            법령명/전문 검색

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,49 @@
+"""Tests for installed lawpy help guidance."""
+
+import subprocess
+import sys
+
+import pytest
+
+import lawpy
+from lawpy.help import guide
+
+
+def test_top_level_help_points_to_main_client() -> None:
+    text = lawpy.help()
+
+    assert "KoreanLawClient" in text
+    assert "LAWPY_KR_API_KEY" in text
+
+
+def test_kr_help_explains_public_wrapper_pattern() -> None:
+    text = guide("kr")
+
+    assert "search_laws" in text
+    assert "search_precedents" in text
+    assert "search_administrative_rules" in text
+    assert "search_ordinances" in text
+
+
+def test_generated_help_explains_direct_import_pattern() -> None:
+    text = guide("generated")
+
+    assert "lawpy.kr.generated.<target>" in text
+    assert "model_dump(by_alias=True)" in text
+    assert "89 generated modules" in text
+
+
+def test_unknown_help_topic_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown lawpy help topic"):
+        guide("missing")
+
+
+def test_help_module_cli() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "lawpy.help", "generated"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Generated-only target pattern" in result.stdout


### PR DESCRIPTION
## Summary
- add an installed help surface via `lawpy.help()` and `python -m lawpy.help`
- document the core `KoreanLawClient` meaning and public wrapper pattern
- document generated-only target usage and the public specs/codegen policy
- add AI-focused docs and tests for the installed guidance

## Verification
- `uv run pytest tests/test_help.py -q`
- `uv run pytest -q`
- `uv run ruff check src/lawpy tests docs`
- `uv run mypy src/lawpy`
- `uv build`

Closes #33