### PR TITLE
feat: add KRClient primary alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,19 @@ export LAWPY_API_KEY="your-email-id"
 Or pass it directly:
 
 ```python
-from lawpy import KoreanLawClient
+from lawpy import KRClient
 
 # Using environment variable
-client = KoreanLawClient()
+client = KRClient()
 
 # Or pass api_key directly
-client = KoreanLawClient(api_key="your-api-key")
+client = KRClient(api_key="your-api-key")
 ```
 
-`KoreanLawClient` is the main ergonomic object for Korean law.go.kr data. It
+`KRClient` is the main ergonomic object for Korean law.go.kr data. It
 combines the public wrappers for laws, precedents, administrative rules,
 notices, local ordinances, and local notices.
+`KoreanLawClient` remains available as a compatibility alias.
 
 #### Search for laws
 
@@ -127,7 +128,7 @@ print(history_detail)  # Returns HTML text
 ### Generated-only targets
 
 KR v1 includes full generated coverage for the public spec inventory. If a
-target does not have a public wrapper on `KoreanLawClient` yet, import the
+target does not have a public wrapper on `KRClient` yet, import the
 generated client directly:
 
 ```python

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -27,21 +27,23 @@ python -m lawpy.help codegen
 
 ## Main Object
 
-Use `KoreanLawClient` first.
+Use `KRClient` first.
 
 ```python
-from lawpy import KoreanLawClient
+from lawpy import KRClient
 
-client = KoreanLawClient(api_key="your-open-law-email-id")
+client = KRClient(api_key="your-open-law-email-id")
 ```
 
-`KoreanLawClient` is the ergonomic public surface for Korean law.go.kr data. It
+`KRClient` is the ergonomic public surface for Korean law.go.kr data. It
 combines the implemented public wrappers for:
 
 - laws
 - precedents
 - administrative rules and notices
 - local ordinances and local notices
+
+`KoreanLawClient` remains available as a compatibility alias for existing code.
 
 ## One Pattern
 
@@ -67,7 +69,7 @@ ordinance = client.get_ordinance_detail(ordinance_id=ordinances[0].자치법규I
 
 ## Generated-Only Targets
 
-If `KoreanLawClient` does not expose a public wrapper for the target, import the
+If `KRClient` does not expose a public wrapper for the target, import the
 generated client directly:
 
 ```python
@@ -95,7 +97,7 @@ generated tests are public.
 
 Support contract:
 
-- Prefer `KoreanLawClient` for stable public workflows.
+- Prefer `KRClient` for stable public workflows.
 - Use generated clients for covered targets without a wrapper.
 - Generated output is reviewed through deterministic diffs, coverage docs, and CI.
 - Raw scraped specs may reflect upstream documentation quirks.

--- a/docs/kr/generated-coverage.md
+++ b/docs/kr/generated-coverage.md
@@ -21,16 +21,17 @@ For v1, "generated coverage" means every generated KR module has:
 - typed Pydantic models where the endpoint response is modeled
 - at least one generated test file covering search/detail behavior available for that target
 
-Public wrappers are tracked separately. They are the ergonomic API layer intended for `KoreanLawClient` and `datapan-data` workflows.
+Public wrappers are tracked separately. They are the ergonomic API layer intended for `KRClient` and `datapan-data` workflows.
+`KoreanLawClient` is kept as a compatibility alias for existing code.
 
 ## Public Wrapper Status
 
 | Target | Public surface | Status |
 | --- | --- | --- |
-| `law` | `LawClient`, `KoreanLawClient` | implemented |
-| `prec` | `PrecedentClient`, `KoreanLawClient` | implemented |
-| `admrul` | `AdministrativeRuleClient`, `KoreanLawClient` | implemented |
-| `ordin` | `OrdinanceClient`, `KoreanLawClient` | implemented |
+| `law` | `LawClient`, `KRClient` | implemented |
+| `prec` | `PrecedentClient`, `KRClient` | implemented |
+| `admrul` | `AdministrativeRuleClient`, `KRClient` | implemented |
+| `ordin` | `OrdinanceClient`, `KRClient` | implemented |
 
 ## Generated Matrix
 
@@ -40,7 +41,7 @@ Public wrappers are tracked separately. They are the ergonomic API layer intende
 | `acrSpecialDecc` | `GeneratedAcrspecialdeccClient` | `search_acrSpecialDeccs`, `get_acrSpecialDecc_detail` | yes | yes | generated only |
 | `adapSpecialDecc` | `GeneratedAdapspecialdeccClient` | `search_adapSpecialDeccs`, `get_adapSpecialDecc_detail` | yes | yes | generated only |
 | `admbyl` | `GeneratedAdmbylClient` | `search_admbyls` | yes | yes | generated only |
-| `admrul` | `GeneratedAdmrulClient` | `search_admruls`, `get_admrul_detail` | yes | yes | `AdministrativeRuleClient`, `KoreanLawClient` |
+| `admrul` | `GeneratedAdmrulClient` | `search_admruls`, `get_admrul_detail` | yes | yes | `AdministrativeRuleClient`, `KRClient` |
 | `admrulOldAndNew` | `GeneratedAdmruloldandnewClient` | `search_admrulOldAndNews`, `get_admrulOldAndNew_detail` | yes | yes | generated only |
 | `baiPvcs` | `GeneratedBaipvcsClient` | `search_baiPvcss`, `get_baiPvcs_detail` | yes | yes | generated only |
 | `couseAdmrul` | `GeneratedCouseadmrulClient` | `search_couseAdmruls` | yes | yes | generated only |
@@ -69,7 +70,7 @@ Public wrappers are tracked separately. They are the ergonomic API layer intende
 | `kmaCgmExpc` | `GeneratedKmacgmexpcClient` | `search_kmaCgmExpcs`, `get_kmaCgmExpc_detail` | yes | yes | generated only |
 | `kmstSpecialDecc` | `GeneratedKmstspecialdeccClient` | `search_kmstSpecialDeccs`, `get_kmstSpecialDecc_detail` | yes | yes | generated only |
 | `kostatCgmExpc` | `GeneratedKostatcgmexpcClient` | `search_kostatCgmExpcs`, `get_kostatCgmExpc_detail` | yes | yes | generated only |
-| `law` | `GeneratedLawClient` | `search_laws`, `get_law_detail` | yes | yes | `LawClient`, `KoreanLawClient` |
+| `law` | `GeneratedLawClient` | `search_laws`, `get_law_detail` | yes | yes | `LawClient`, `KRClient` |
 | `lawjosub` | `GeneratedLawjosubClient` | `search_lawjosubs` | yes | yes | generated only |
 | `licbyl` | `GeneratedLicbylClient` | `search_licbyls` | yes | yes | generated only |
 | `lnkLs` | `GeneratedLnklsClient` | `search_lnkLss` | yes | yes | generated only |
@@ -114,11 +115,11 @@ Public wrappers are tracked separately. They are the ergonomic API layer intende
 | `okaCgmExpc` | `GeneratedOkacgmexpcClient` | `search_okaCgmExpcs`, `get_okaCgmExpc_detail` | yes | yes | generated only |
 | `oldAndNew` | `GeneratedOldandnewClient` | `search_oldAndNews`, `get_oldAndNew_detail` | yes | yes | generated only |
 | `oneview` | `GeneratedOneviewClient` | `search_oneviews`, `get_oneview_detail` | yes | yes | generated only |
-| `ordin` | `GeneratedOrdinClient` | `search_ordins`, `get_ordin_detail` | yes | yes | `OrdinanceClient`, `KoreanLawClient` |
+| `ordin` | `GeneratedOrdinClient` | `search_ordins`, `get_ordin_detail` | yes | yes | `OrdinanceClient`, `KRClient` |
 | `ordinbyl` | `GeneratedOrdinbylClient` | `search_ordinbyls` | yes | yes | generated only |
 | `ppc` | `GeneratedPpcClient` | `search_ppcs`, `get_ppc_detail` | yes | yes | generated only |
 | `ppsCgmExpc` | `GeneratedPpscgmexpcClient` | `search_ppsCgmExpcs`, `get_ppsCgmExpc_detail` | yes | yes | generated only |
-| `prec` | `GeneratedPrecClient` | `search_precs`, `get_prec_detail` | yes | yes | `PrecedentClient`, `KoreanLawClient` |
+| `prec` | `GeneratedPrecClient` | `search_precs`, `get_prec_detail` | yes | yes | `PrecedentClient`, `KRClient` |
 | `rdaCgmExpc` | `GeneratedRdacgmexpcClient` | `search_rdaCgmExpcs`, `get_rdaCgmExpc_detail` | yes | yes | generated only |
 | `school` | `GeneratedSchoolClient` | `search_schools`, `get_school_detail` | yes | yes | generated only |
 | `sfc` | `GeneratedSfcClient` | `search_sfcs`, `get_sfc_detail` | yes | yes | generated only |

--- a/src/lawpy/__init__.py
+++ b/src/lawpy/__init__.py
@@ -5,16 +5,22 @@ Installed quickstart:
     print(lawpy.help())
 
 Main Korean API object:
-    from lawpy import KoreanLawClient
+    from lawpy import KRClient
 
-    client = KoreanLawClient(api_key="your-open-law-email-id")
+    client = KRClient(api_key="your-open-law-email-id")
     laws = client.search_laws("민법", per_page=5)
 
 Use lawpy.help("kr") for public wrapper methods and
 lawpy.help("generated") for generated-only KR targets.
 """
 
-from lawpy.kr import AdministrativeRuleClient, KoreanLawClient, OrdinanceClient, PrecedentClient
+from lawpy.kr import (
+    AdministrativeRuleClient,
+    KoreanLawClient,
+    KRClient,
+    OrdinanceClient,
+    PrecedentClient,
+)
 from lawpy.kr.generated._models_generated import AdmrulDetail, AdmrulList, OrdinDetail, OrdinList
 from lawpy.models import (
     Article,
@@ -48,6 +54,7 @@ __all__ = [
     "AdministrativeRuleClient",
     "AdmrulDetail",
     "AdmrulList",
+    "KRClient",
     "KoreanLawClient",
     "OrdinanceClient",
     "OrdinDetail",

--- a/src/lawpy/help.py
+++ b/src/lawpy/help.py
@@ -19,17 +19,18 @@ QUICKSTART = dedent(
     =================
 
     Main object:
-        KoreanLawClient
+        KRClient
 
     Meaning:
-        KoreanLawClient is the ergonomic entry point for Korean law.go.kr data.
+        KRClient is the ergonomic entry point for Korean law.go.kr data.
         It combines the public wrappers for law, precedent, administrative rule,
         and local ordinance workflows.
+        KoreanLawClient is kept as a compatibility alias.
 
     Basic pattern:
-        from lawpy import KoreanLawClient
+        from lawpy import KRClient
 
-        client = KoreanLawClient(api_key="your-open-law-email-id")
+        client = KRClient(api_key="your-open-law-email-id")
         results = client.search_laws("민법", per_page=5)
         detail = client.get_law_detail(law_id=results[0].law_id)
 
@@ -46,11 +47,11 @@ QUICKSTART = dedent(
 
 KR = dedent(
     """
-    KoreanLawClient pattern
-    =======================
+    KRClient pattern
+    ================
 
-    Use KoreanLawClient first. It is the stable public surface for common
-    datapan-data workflows.
+    Use KRClient first. It is the stable public surface for common datapan-data
+    workflows. KoreanLawClient is a compatibility alias for existing code.
 
     Public wrapper methods:
         Law:
@@ -90,7 +91,7 @@ GENERATED = dedent(
     Generated-only target pattern
     =============================
 
-    If KoreanLawClient does not expose a public wrapper yet, import the generated
+    If KRClient does not expose a public wrapper yet, import the generated
     client directly from lawpy.kr.generated.<target>.
 
     Example:
@@ -124,7 +125,7 @@ CODEGEN = dedent(
     models, and generated tests public.
 
     Support contract:
-        - Prefer KoreanLawClient for stable public workflows.
+        - Prefer KRClient for stable public workflows.
         - Use generated clients for covered targets without a wrapper.
         - Generated code is reviewed through deterministic diffs, coverage docs,
           and CI tests.

--- a/src/lawpy/kr/README.md
+++ b/src/lawpy/kr/README.md
@@ -63,9 +63,9 @@ lawpy/kr/
 ### Integrated Client (All APIs)
 
 ```python
-from lawpy.kr import KoreanLawClient
+from lawpy.kr import KRClient
 
-client = KoreanLawClient(api_key="your_email_id")
+client = KRClient(api_key="your_email_id")
 
 # Law APIs
 laws = client.search_laws("민법")
@@ -200,8 +200,8 @@ export LAWPY_API_KEY=your_email_id
 Or pass it directly:
 
 ```python
-from lawpy.kr import KoreanLawClient
-client = KoreanLawClient(api_key="your_email_id")
+from lawpy.kr import KRClient
+client = KRClient(api_key="your_email_id")
 ```
 
 ## References

--- a/src/lawpy/kr/__init__.py
+++ b/src/lawpy/kr/__init__.py
@@ -1,11 +1,13 @@
 """Korean law API modules.
 
-Start with KoreanLawClient for normal use:
+Start with KRClient for normal use:
 
-    from lawpy import KoreanLawClient
+    from lawpy import KRClient
 
-    client = KoreanLawClient(api_key="your-open-law-email-id")
+    client = KRClient(api_key="your-open-law-email-id")
     laws = client.search_laws("민법", per_page=5)
+
+KoreanLawClient is kept as a compatibility alias.
 
 For installed guidance, run:
 
@@ -14,9 +16,16 @@ For installed guidance, run:
 """
 
 from lawpy.kr.administrative_rule import AdministrativeRuleClient
-from lawpy.kr.client import KoreanLawClient
+from lawpy.kr.client import KoreanLawClient, KRClient
 from lawpy.kr.law import LawClient
 from lawpy.kr.ordinance import OrdinanceClient
 from lawpy.kr.precedent import PrecedentClient
 
-__all__ = ["AdministrativeRuleClient", "KoreanLawClient", "LawClient", "OrdinanceClient", "PrecedentClient"]
+__all__ = [
+    "AdministrativeRuleClient",
+    "KRClient",
+    "KoreanLawClient",
+    "LawClient",
+    "OrdinanceClient",
+    "PrecedentClient",
+]

--- a/src/lawpy/kr/client.py
+++ b/src/lawpy/kr/client.py
@@ -6,17 +6,21 @@ from lawpy.kr.ordinance import OrdinanceClient
 from lawpy.kr.precedent import PrecedentClient
 
 
-class KoreanLawClient(LawClient, PrecedentClient, AdministrativeRuleClient, OrdinanceClient):
+class KRClient(LawClient, PrecedentClient, AdministrativeRuleClient, OrdinanceClient):
     """Integrated client for Korean National Law Information Center API.
 
     Provides a single entry-point for all implemented Korean law open-data APIs.
-    This is the object most users and AI agents should try first.
+    This is the primary object most users and AI agents should try first.
 
     Basic pattern:
-      >>> from lawpy import KoreanLawClient
-      >>> client = KoreanLawClient(api_key="your-open-law-email-id")
+      >>> from lawpy import KRClient
+      >>> client = KRClient(api_key="your-open-law-email-id")
       >>> laws = client.search_laws("민법", per_page=5)
       >>> detail = client.get_law_detail(law_id=laws[0].law_id)
+
+    ``KoreanLawClient`` remains available as a compatibility alias. New code
+    should prefer ``KRClient`` so future country/region modules can follow the
+    same pattern, such as ``USClient`` or ``EUClient``.
 
     If a target is not exposed here yet, use the generated client under
     ``lawpy.kr.generated.<target>``. Run ``import lawpy; print(lawpy.help())``
@@ -54,3 +58,6 @@ class KoreanLawClient(LawClient, PrecedentClient, AdministrativeRuleClient, Ordi
     """
 
     pass
+
+
+KoreanLawClient = KRClient

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -12,6 +12,7 @@ from lawpy.help import guide
 def test_top_level_help_points_to_main_client() -> None:
     text = lawpy.help()
 
+    assert "KRClient" in text
     assert "KoreanLawClient" in text
     assert "LAWPY_KR_API_KEY" in text
 

--- a/tests/test_kr.py
+++ b/tests/test_kr.py
@@ -5,42 +5,49 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+import lawpy
 from lawpy.exceptions import APIError, NotFoundError
-from lawpy.kr import KoreanLawClient
+from lawpy.kr import KoreanLawClient, KRClient
 
 
 @pytest.fixture
 def client():
     """Create a test client."""
-    return KoreanLawClient(api_key="test_key")
+    return KRClient(api_key="test_key")
 
 
-class TestKoreanLawClient:
-    """Tests for KoreanLawClient."""
+class TestKRClient:
+    """Tests for KRClient."""
+
+    def test_top_level_export(self):
+        """Test top-level and module exports point to the same client."""
+        assert lawpy.KRClient is KRClient
+        assert lawpy.KoreanLawClient is KRClient
+        assert KoreanLawClient is KRClient
 
     def test_init(self, client):
         """Test client initialization."""
         assert client.api_key == "test_key"
-        assert client.base_url == KoreanLawClient.BASE_URL
+        assert client.base_url == KRClient.BASE_URL
         assert client.timeout == 30
 
     def test_init_from_env(self):
         """Test client initialization from environment variable."""
         with patch.dict(os.environ, {"LAWPY_API_KEY": "env_key"}):
-            client = KoreanLawClient()
+            client = KRClient()
             assert client.api_key == "env_key"
 
     def test_init_env_override(self):
         """Test that explicit api_key overrides environment variable."""
         with patch.dict(os.environ, {"LAWPY_API_KEY": "env_key"}):
-            client = KoreanLawClient(api_key="explicit_key")
+            client = KRClient(api_key="explicit_key")
             assert client.api_key == "explicit_key"
 
     def test_init_no_api_key(self):
         """Test error when no api_key is provided."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError) as exc_info:
-                KoreanLawClient()
+                KRClient()
 
             assert "LAWPY_KR_API_KEY" in str(exc_info.value)
 


### PR DESCRIPTION
## Summary

- make `KRClient` the primary Korean public client export at `lawpy` and `lawpy.kr`
- keep `KoreanLawClient` as a compatibility alias for existing users
- update installed help, README, AI usage docs, and coverage docs to point to `KRClient`
- add tests that lock top-level/module alias behavior

## Verification

- `uv run ruff check src/lawpy tests docs`
- `uv run mypy src/lawpy`
- `uv run pytest -q`
- `uv build`

Closes #36