### PR TITLE
fix: make uv dev test commands work from clean checkout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,4 +131,12 @@ replace = '__version__ = "{new_version}"'
 [dependency-groups]
 dev = [
     "beautifulsoup4>=4.14.3",
+    "pytest>=8.0.0",
+    "pytest-cov>=5.0.0",
+    "pytest-asyncio>=0.23.0",
+    "responses>=0.25.0",
+    "ruff>=0.6.0",
+    "mypy>=1.11.0",
+    "types-requests>=2.32.0",
+    "bump-my-version>=0.27.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -421,6 +421,14 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "beautifulsoup4" },
+    { name = "bump-my-version" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "responses" },
+    { name = "ruff" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -440,7 +448,17 @@ requires-dist = [
 provides-extras = ["dev", "probe"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "beautifulsoup4", specifier = ">=4.14.3" }]
+dev = [
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
+    { name = "bump-my-version", specifier = ">=0.27.0" },
+    { name = "mypy", specifier = ">=1.11.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "responses", specifier = ">=0.25.0" },
+    { name = "ruff", specifier = ">=0.6.0" },
+    { name = "types-requests", specifier = ">=2.32.0" },
+]
 
 [[package]]
 name = "librt"


### PR DESCRIPTION
## Summary

- add test, lint, typing, and release tools to the uv dev dependency group
- keep the existing dev extra for compatibility
- update uv.lock so uv run pytest works from a clean checkout

## Verification

- uv run pytest -q tests/test_help.py
- uv run ruff check src/lawpy tests docs
- uv run mypy src/lawpy
- uv lock --check

Closes #10