### PR TITLE
Fix release version bump command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Bump version
         run: |
-          uv run bump-my-version ${{ github.event.inputs.version_bump }}
+          uv run bump-my-version bump ${{ github.event.inputs.version_bump }}
 
       - name: Push changes
         run: |


### PR DESCRIPTION
## Summary
- fix release workflow to call the current bump-my-version CLI as `bump-my-version bump <part>`
- verify minor bump still resolves to 0.2.0

## Validation
- `uv run bump-my-version show-bump`
- `git diff --check`