### PR TITLE
Allow release workflow to publish dispatched tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,17 @@ on:
     inputs:
       version_bump:
         description: 'Version bump type (major, minor, patch)'
-        required: true
+        required: false
         default: 'patch'
         type: choice
         options:
           - major
           - minor
           - patch
+      publish_tag:
+        description: 'Existing tag to publish instead of bumping, e.g. v0.2.0'
+        required: false
+        type: string
   push:
     tags:
       - "v*.*.*"
@@ -24,7 +28,9 @@ jobs:
   bump-version:
     name: Bump Version
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_tag == ''
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
 
     steps:
       - name: Checkout
@@ -55,6 +61,11 @@ jobs:
         run: |
           uv run bump-my-version bump ${{ github.event.inputs.version_bump }}
 
+      - name: Capture bumped tag
+        id: version
+        run: |
+          echo "tag=v$(uv run bump-my-version show current_version)" >> "$GITHUB_OUTPUT"
+
       - name: Push changes
         run: |
           git push origin main
@@ -63,11 +74,14 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    needs: bump-version
+    if: always() && (github.event_name == 'push' || github.event.inputs.publish_tag != '' || needs.bump-version.result == 'success')
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.publish_tag || needs.bump-version.outputs.tag || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -88,14 +102,27 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: publish
-    if: github.event_name == 'push'
+    needs:
+      - bump-version
+      - publish
+    if: always() && needs.publish.result == 'success'
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.publish_tag || needs.bump-version.outputs.tag || github.ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Build package
+        run: uv build
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.publish_tag || needs.bump-version.outputs.tag || github.ref_name }}
           generate_release_notes: true
           files: dist/*


### PR DESCRIPTION
## Summary
- allow release workflow dispatch to publish an existing tag such as v0.2.0
- keep normal dispatch bump flow publishable in the same workflow run
- rebuild release artifacts in the GitHub Release job so dist/* exists

## Validation
- uv build
- workflow YAML parsed with PyYAML
- git diff --check