### PR TITLE
Set PyPI release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
     needs: bump-version
     if: always() && (github.event_name == 'push' || github.event.inputs.publish_tag != '' || needs.bump-version.result == 'success')
 


### PR DESCRIPTION
## Summary
- set the publish job environment to `pypi` so Trusted Publishing includes the expected environment claim

## Validation
- workflow YAML parsed with PyYAML
- git diff --check