### PR TITLE
Fix fresh spec auto-update codegen

### DIFF
--- a/scripts/codegen.py
+++ b/scripts/codegen.py
@@ -32,9 +32,28 @@ RESP_KEY_CANDIDATES = ["출력변수", "출력결과", "필드", "요청변수",
 DESC_KEY = "설명"
 VAL_KEY = "값"
 DETAIL_COMPAT_FIELDS: dict[str, list[tuple[str, str]]] = {
+    "decc": [
+        ("행정심판례일련번호", "행정심판례일련번호"),
+        ("사건명", "사건명"),
+        ("사건번호", "사건번호"),
+        ("주문", "주문"),
+    ],
     "detc": [("id", "ID"), ("lm", "LM")],
     "expc": [("id", "ID"), ("lm", "LM")],
     "trty": [("id", "ID")],
+}
+MODEL_COMPAT_FIELDS: dict[tuple[str, str], list[tuple[str, str]]] = {
+    ("decc", "List"): [
+        ("행정심판재결례일련번호", "행정심판재결례일련번호"),
+        ("사건명", "사건명"),
+        ("사건번호", "사건번호"),
+        ("의결일자", "의결일자"),
+    ],
+    ("ordin", "List"): [
+        ("자치법규명", "자치법규명"),
+        ("자치법규일련번호", "자치법규일련번호"),
+        ("자치법규종류", "자치법규종류"),
+    ],
 }
 MOBILE_COMPAT_PARAMS: dict[str, list[dict[str, object]]] = {
     target: [
@@ -379,7 +398,22 @@ def render_list_method(spec: dict, target: str, root_key: str | None, item_key: 
         parse_block = (
             f'        data = response.json()\n'
             f'        root = data.get("{root_key}", {{}})\n'
-            f'        items = root if isinstance(root, list) else [root] if root else []\n'
+            f'        if isinstance(root, list):\n'
+            f'            items = root\n'
+            f'        elif isinstance(root, dict):\n'
+            f'            items = []\n'
+            f'            found_items = False\n'
+            f'            for value in root.values():\n'
+            f'                if isinstance(value, list):\n'
+            f'                    items = value\n'
+            f'                    found_items = True\n'
+            f'                    break\n'
+            f'            if not found_items and root:\n'
+            f'                items = [root]\n'
+            f'        else:\n'
+            f'            items = []\n'
+            f'        if isinstance(items, dict):\n'
+            f'            items = [items]\n'
             f'        return [{model_cls}.model_validate(item) for item in items]\n'
         )
         note = f"Response path: {root_key} (item key not discovered)"
@@ -599,6 +633,15 @@ def render_test_file(
         assert len(result) == 1
         assert isinstance(result[0], {list_model})''')
 
+    if has_list and root_key_search and not item_key:
+        test_methods.append(f'''\
+    def test_search_nested_empty_list_response(self):
+        client = _make_client()
+        client._make_request = Mock(return_value=_mock_response({{"{root_key_search}": {{"items": []}}}}))
+        result = client.search_{target}s()
+        assert isinstance(result, list)
+        assert len(result) == 0''')
+
     if has_detail:
         detail_params = extract_params(specs["info"])
         first_detail_param = detail_params[0] if detail_params else None
@@ -675,6 +718,21 @@ def render_model(target: str, kind: str, label: str, fields: list[dict], html_na
         if field_lines == ["    pass  # no response fields in spec"]:
             field_lines = []
         for pyname, alias in DETAIL_COMPAT_FIELDS[target]:
+            if pyname not in existing_pynames:
+                field_lines.append(f'    {pyname}: str | None = Field(None, alias="{alias}")')
+
+    compat_fields = MODEL_COMPAT_FIELDS.get((target, kind), [])
+    if compat_fields:
+        existing_pynames = {
+            f["pyname"] for f in fields
+        } | {
+            line.split(":", 1)[0].strip()
+            for line in field_lines
+            if ":" in line
+        }
+        if field_lines == ["    pass  # no response fields in spec"]:
+            field_lines = []
+        for pyname, alias in compat_fields:
             if pyname not in existing_pynames:
                 field_lines.append(f'    {pyname}: str | None = Field(None, alias="{alias}")')
 

--- a/src/lawpy/kr/generated/_models_generated.py
+++ b/src/lawpy/kr/generated/_models_generated.py
@@ -3917,6 +3917,7 @@ class OrdinList(BaseModel):
     자치법규상세링크: str | None = Field(None, alias="자치법규상세링크")
     자치법규분야명: str | None = Field(None, alias="자치법규분야명")
     참조데이터구분: str | None = Field(None, alias="참조데이터구분")
+    자치법규일련번호: str | None = Field(None, alias="자치법규일련번호")
 
 class OrdinDetail(BaseModel):
     """[GENERATED] Response model for 자치법규 본문 조회.

--- a/src/lawpy/kr/generated/baiPvcs.py
+++ b/src/lawpy/kr/generated/baiPvcs.py
@@ -71,7 +71,22 @@ class GeneratedBaipvcsClient(KoreanBaseClient):
         response = self._make_request(self.BASE_URL, params=params)
         data = response.json()
         root = data.get("BaiPvcs", {})
-        items = root if isinstance(root, list) else [root] if root else []
+        if isinstance(root, list):
+            items = root
+        elif isinstance(root, dict):
+            items = []
+            found_items = False
+            for value in root.values():
+                if isinstance(value, list):
+                    items = value
+                    found_items = True
+                    break
+            if not found_items and root:
+                items = [root]
+        else:
+            items = []
+        if isinstance(items, dict):
+            items = [items]
         return [BaipvcsList.model_validate(item) for item in items]
 
     def get_baiPvcs_detail(

--- a/src/lawpy/kr/generated/licbyl.py
+++ b/src/lawpy/kr/generated/licbyl.py
@@ -75,6 +75,21 @@ class GeneratedLicbylClient(KoreanBaseClient):
         response = self._make_request(self.BASE_URL, params=params)
         data = response.json()
         root = data.get("licBylSearch", {})
-        items = root if isinstance(root, list) else [root] if root else []
+        if isinstance(root, list):
+            items = root
+        elif isinstance(root, dict):
+            items = []
+            found_items = False
+            for value in root.values():
+                if isinstance(value, list):
+                    items = value
+                    found_items = True
+                    break
+            if not found_items and root:
+                items = [root]
+        else:
+            items = []
+        if isinstance(items, dict):
+            items = [items]
         return [LicbylList.model_validate(item) for item in items]
 

--- a/src/lawpy/kr/generated/lnkLs.py
+++ b/src/lawpy/kr/generated/lnkLs.py
@@ -51,6 +51,21 @@ class GeneratedLnklsClient(KoreanBaseClient):
         response = self._make_request(self.BASE_URL, params=params)
         data = response.json()
         root = data.get("LawSearch", {})
-        items = root if isinstance(root, list) else [root] if root else []
+        if isinstance(root, list):
+            items = root
+        elif isinstance(root, dict):
+            items = []
+            found_items = False
+            for value in root.values():
+                if isinstance(value, list):
+                    items = value
+                    found_items = True
+                    break
+            if not found_items and root:
+                items = [root]
+        else:
+            items = []
+        if isinstance(items, dict):
+            items = [items]
         return [LnklsList.model_validate(item) for item in items]
 

--- a/src/lawpy/kr/generated/lnkOrd.py
+++ b/src/lawpy/kr/generated/lnkOrd.py
@@ -51,6 +51,21 @@ class GeneratedLnkordClient(KoreanBaseClient):
         response = self._make_request(self.BASE_URL, params=params)
         data = response.json()
         root = data.get("OrdinSearch", {})
-        items = root if isinstance(root, list) else [root] if root else []
+        if isinstance(root, list):
+            items = root
+        elif isinstance(root, dict):
+            items = []
+            found_items = False
+            for value in root.values():
+                if isinstance(value, list):
+                    items = value
+                    found_items = True
+                    break
+            if not found_items and root:
+                items = [root]
+        else:
+            items = []
+        if isinstance(items, dict):
+            items = [items]
         return [LnkordList.model_validate(item) for item in items]
 

--- a/src/lawpy/kr/generated/lsHstInf.py
+++ b/src/lawpy/kr/generated/lsHstInf.py
@@ -51,6 +51,21 @@ class GeneratedLshstinfClient(KoreanBaseClient):
         response = self._make_request(self.BASE_URL, params=params)
         data = response.json()
         root = data.get("LawSearch", {})
-        items = root if isinstance(root, list) else [root] if root else []
+        if isinstance(root, list):
+            items = root
+        elif isinstance(root, dict):
+            items = []
+            found_items = False
+            for value in root.values():
+                if isinstance(value, list):
+                    items = value
+                    found_items = True
+                    break
+            if not found_items and root:
+                items = [root]
+        else:
+            items = []
+        if isinstance(items, dict):
+            items = [items]
         return [LshstinfList.model_validate(item) for item in items]
 

--- a/src/lawpy/kr/generated/lsJoHstInf.py
+++ b/src/lawpy/kr/generated/lsJoHstInf.py
@@ -47,6 +47,21 @@ class GeneratedLsjohstinfClient(KoreanBaseClient):
         response = self._make_request(self.SERVICE_URL, params=params)
         data = response.json()
         root = data.get("LawSearch", {})
-        items = root if isinstance(root, list) else [root] if root else []
+        if isinstance(root, list):
+            items = root
+        elif isinstance(root, dict):
+            items = []
+            found_items = False
+            for value in root.values():
+                if isinstance(value, list):
+                    items = value
+                    found_items = True
+                    break
+            if not found_items and root:
+                items = [root]
+        else:
+            items = []
+        if isinstance(items, dict):
+            items = [items]
         return [LsjohstinfList.model_validate(item) for item in items]
 

--- a/src/lawpy/kr/generated/oneview.py
+++ b/src/lawpy/kr/generated/oneview.py
@@ -43,7 +43,22 @@ class GeneratedOneviewClient(KoreanBaseClient):
         response = self._make_request(self.BASE_URL, params=params)
         data = response.json()
         root = data.get("items", {})
-        items = root if isinstance(root, list) else [root] if root else []
+        if isinstance(root, list):
+            items = root
+        elif isinstance(root, dict):
+            items = []
+            found_items = False
+            for value in root.values():
+                if isinstance(value, list):
+                    items = value
+                    found_items = True
+                    break
+            if not found_items and root:
+                items = [root]
+        else:
+            items = []
+        if isinstance(items, dict):
+            items = [items]
         return [OneviewList.model_validate(item) for item in items]
 
     def get_oneview_detail(

--- a/src/lawpy/kr/generated/ordinbyl.py
+++ b/src/lawpy/kr/generated/ordinbyl.py
@@ -75,6 +75,21 @@ class GeneratedOrdinbylClient(KoreanBaseClient):
         response = self._make_request(self.BASE_URL, params=params)
         data = response.json()
         root = data.get("licBylSearch", {})
-        items = root if isinstance(root, list) else [root] if root else []
+        if isinstance(root, list):
+            items = root
+        elif isinstance(root, dict):
+            items = []
+            found_items = False
+            for value in root.values():
+                if isinstance(value, list):
+                    items = value
+                    found_items = True
+                    break
+            if not found_items and root:
+                items = [root]
+        else:
+            items = []
+        if isinstance(items, dict):
+            items = [items]
         return [OrdinbylList.model_validate(item) for item in items]
 

--- a/tests/test_generated/test_baiPvcs.py
+++ b/tests/test_generated/test_baiPvcs.py
@@ -39,6 +39,13 @@ class TestGeneratedBaipvcsClient:
         call_params = client._make_request.call_args.kwargs.get("params", client._make_request.call_args[1].get("params", {}))
         assert "search" in call_params
 
+    def test_search_nested_empty_list_response(self):
+        client = _make_client()
+        client._make_request = Mock(return_value=_mock_response({"BaiPvcs": {"items": []}}))
+        result = client.search_baiPvcss()
+        assert isinstance(result, list)
+        assert len(result) == 0
+
     def test_detail_returns_model(self):
         client = _make_client()
         client._make_request = Mock(return_value=_mock_response({"BaiPvcs": {"감사원사전컨설팅의견서일련번호": "val", "의견서명": "val", "회신일자": "val"}}))

--- a/tests/test_generated/test_licbyl.py
+++ b/tests/test_generated/test_licbyl.py
@@ -45,3 +45,10 @@ class TestGeneratedLicbylClient:
         client.search_licbyls(mobileyn="Y")
         call_params = client._make_request.call_args.kwargs.get("params", client._make_request.call_args[1].get("params", {}))
         assert call_params["mobileYn"] == "Y"
+
+    def test_search_nested_empty_list_response(self):
+        client = _make_client()
+        client._make_request = Mock(return_value=_mock_response({"licBylSearch": {"items": []}}))
+        result = client.search_licbyls()
+        assert isinstance(result, list)
+        assert len(result) == 0

--- a/tests/test_generated/test_lnkLs.py
+++ b/tests/test_generated/test_lnkLs.py
@@ -38,3 +38,10 @@ class TestGeneratedLnklsClient:
         client.search_lnkLss(query="test")
         call_params = client._make_request.call_args.kwargs.get("params", client._make_request.call_args[1].get("params", {}))
         assert "query" in call_params
+
+    def test_search_nested_empty_list_response(self):
+        client = _make_client()
+        client._make_request = Mock(return_value=_mock_response({"LawSearch": {"items": []}}))
+        result = client.search_lnkLss()
+        assert isinstance(result, list)
+        assert len(result) == 0

--- a/tests/test_generated/test_lnkOrd.py
+++ b/tests/test_generated/test_lnkOrd.py
@@ -38,3 +38,10 @@ class TestGeneratedLnkordClient:
         client.search_lnkOrds(query="test")
         call_params = client._make_request.call_args.kwargs.get("params", client._make_request.call_args[1].get("params", {}))
         assert "query" in call_params
+
+    def test_search_nested_empty_list_response(self):
+        client = _make_client()
+        client._make_request = Mock(return_value=_mock_response({"OrdinSearch": {"items": []}}))
+        result = client.search_lnkOrds()
+        assert isinstance(result, list)
+        assert len(result) == 0

--- a/tests/test_generated/test_lsHstInf.py
+++ b/tests/test_generated/test_lsHstInf.py
@@ -38,3 +38,10 @@ class TestGeneratedLshstinfClient:
         client.search_lsHstInfs(regdt=1)
         call_params = client._make_request.call_args.kwargs.get("params", client._make_request.call_args[1].get("params", {}))
         assert "regDt" in call_params
+
+    def test_search_nested_empty_list_response(self):
+        client = _make_client()
+        client._make_request = Mock(return_value=_mock_response({"LawSearch": {"items": []}}))
+        result = client.search_lsHstInfs()
+        assert isinstance(result, list)
+        assert len(result) == 0

--- a/tests/test_generated/test_lsJoHstInf.py
+++ b/tests/test_generated/test_lsJoHstInf.py
@@ -38,3 +38,10 @@ class TestGeneratedLsjohstinfClient:
         client.search_lsJoHstInfs(id="test")
         call_params = client._make_request.call_args.kwargs.get("params", client._make_request.call_args[1].get("params", {}))
         assert "ID" in call_params
+
+    def test_search_nested_empty_list_response(self):
+        client = _make_client()
+        client._make_request = Mock(return_value=_mock_response({"LawSearch": {"items": []}}))
+        result = client.search_lsJoHstInfs()
+        assert isinstance(result, list)
+        assert len(result) == 0

--- a/tests/test_generated/test_oneview.py
+++ b/tests/test_generated/test_oneview.py
@@ -39,6 +39,13 @@ class TestGeneratedOneviewClient:
         call_params = client._make_request.call_args.kwargs.get("params", client._make_request.call_args[1].get("params", {}))
         assert "query" in call_params
 
+    def test_search_nested_empty_list_response(self):
+        client = _make_client()
+        client._make_request = Mock(return_value=_mock_response({"items": {"items": []}}))
+        result = client.search_oneviews()
+        assert isinstance(result, list)
+        assert len(result) == 0
+
     def test_detail_returns_model(self):
         client = _make_client()
         client._make_request = Mock(return_value=_mock_response({"items": {"패턴일련번호": "val", "법령일련번호": "val", "법령명": "val"}}))

--- a/tests/test_generated/test_ordinbyl.py
+++ b/tests/test_generated/test_ordinbyl.py
@@ -45,3 +45,10 @@ class TestGeneratedOrdinbylClient:
         client.search_ordinbyls(mobileyn="Y")
         call_params = client._make_request.call_args.kwargs.get("params", client._make_request.call_args[1].get("params", {}))
         assert call_params["mobileYn"] == "Y"
+
+    def test_search_nested_empty_list_response(self):
+        client = _make_client()
+        client._make_request = Mock(return_value=_mock_response({"licBylSearch": {"items": []}}))
+        result = client.search_ordinbyls()
+        assert isinstance(result, list)
+        assert len(result) == 0


### PR DESCRIPTION
## Summary
- harden generated root-key-only list parsing for nested list responses
- keep known decc and ordin compatibility fields when fresh specs omit them
- add generated regression coverage for empty nested list responses

## Validation
- uv run ruff check .
- uv run mypy src
- uv run pytest -q

Closes #65