### PR TITLE
Retry transient spec scrape failures

### DIFF
--- a/scripts/scrape_specs.py
+++ b/scripts/scrape_specs.py
@@ -21,11 +21,44 @@ from bs4 import BeautifulSoup
 
 GUIDE_LIST_URL = "https://open.law.go.kr/LSO/openApi/guideList.do"
 GUIDE_RESULT_URL = "https://open.law.go.kr/LSO/openApi/guideResult.do"
+DEFAULT_RETRIES = 3
+DEFAULT_RETRY_DELAY = 1.0
 
 
-def get_all_guide_names() -> list[tuple[str, str]]:
+def request_with_retries(
+    request,
+    url: str,
+    *,
+    attempts: int = DEFAULT_RETRIES,
+    retry_delay: float = DEFAULT_RETRY_DELAY,
+    **kwargs,
+) -> httpx.Response:
+    """Run an HTTP request with small backoff for transient scrape failures."""
+    attempts = max(attempts, 1)
+    for attempt in range(1, attempts + 1):
+        try:
+            response = request(url, **kwargs)
+            if response.status_code < 500 or attempt == attempts:
+                return response
+            response.close()
+        except httpx.TransportError:
+            if attempt == attempts:
+                raise
+        time.sleep(retry_delay * (2 ** (attempt - 1)))
+    raise RuntimeError("unreachable retry state")
+
+
+def get_all_guide_names(
+    *, retries: int = DEFAULT_RETRIES, retry_delay: float = DEFAULT_RETRY_DELAY
+) -> list[tuple[str, str]]:
     """Extract all (html_name, label) from the guide list page."""
-    resp = httpx.get(GUIDE_LIST_URL, timeout=30)
+    resp = request_with_retries(
+        httpx.get,
+        GUIDE_LIST_URL,
+        timeout=30,
+        attempts=retries,
+        retry_delay=retry_delay,
+    )
     resp.raise_for_status()
     soup = BeautifulSoup(resp.text, "html.parser")
 
@@ -64,13 +97,23 @@ def parse_table(table) -> list[dict[str, str]]:
     return rows
 
 
-def scrape_guide(html_name: str, label: str, client: httpx.Client) -> dict:
+def scrape_guide(
+    html_name: str,
+    label: str,
+    client: httpx.Client,
+    *,
+    retries: int = DEFAULT_RETRIES,
+    retry_delay: float = DEFAULT_RETRY_DELAY,
+) -> dict:
     """Fetch one guide page and extract URL + param/response tables."""
-    resp = client.post(
+    resp = request_with_retries(
+        client.post,
         GUIDE_RESULT_URL,
         data={"htmlName": html_name},
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         timeout=30,
+        attempts=retries,
+        retry_delay=retry_delay,
     )
     resp.raise_for_status()
     soup = BeautifulSoup(resp.text, "html.parser")
@@ -138,6 +181,13 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Scrape Korean law API guide specs")
     parser.add_argument("--output", default="specs/kr", help="Output directory")
     parser.add_argument("--delay", type=float, default=0.3, help="Delay between requests (s)")
+    parser.add_argument("--retries", type=int, default=DEFAULT_RETRIES, help="HTTP retry attempts")
+    parser.add_argument(
+        "--retry-delay",
+        type=float,
+        default=DEFAULT_RETRY_DELAY,
+        help="Initial retry delay in seconds",
+    )
     parser.add_argument("--limit", type=int, default=0, help="Max guides to scrape (0=all)")
     args = parser.parse_args()
 
@@ -145,7 +195,7 @@ def main() -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     print("Fetching guide list...", flush=True)
-    guides = get_all_guide_names()
+    guides = get_all_guide_names(retries=args.retries, retry_delay=args.retry_delay)
     print(f"Found {len(guides)} guide pages")
 
     if args.limit:
@@ -158,7 +208,13 @@ def main() -> None:
             out_path = out_dir / f"{html_name}.json"
             print(f"  [{i:>3}/{len(guides)}] {html_name:<45} ", end="", flush=True)
             try:
-                spec = scrape_guide(html_name, label, client)
+                spec = scrape_guide(
+                    html_name,
+                    label,
+                    client,
+                    retries=args.retries,
+                    retry_delay=args.retry_delay,
+                )
                 out_path.write_text(
                     json.dumps(spec, ensure_ascii=False, indent=2), encoding="utf-8"
                 )

--- a/tests/test_scrape_specs.py
+++ b/tests/test_scrape_specs.py
@@ -1,0 +1,113 @@
+"""Regression tests for spec scraper network retry behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+
+
+def _load_scrape_specs_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "scrape_specs.py"
+    spec = importlib.util.spec_from_file_location("lawpy_scrape_specs", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Response:
+    def __init__(self, text: str, *, status_code: int = 200) -> None:
+        self.text = text
+        self.status_code = status_code
+        self.url = "https://open.law.go.kr/test"
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "error",
+                request=httpx.Request("GET", self.url),
+                response=httpx.Response(self.status_code),
+            )
+
+
+def test_get_all_guide_names_retries_transient_dns_failure(monkeypatch) -> None:
+    scrape_specs = _load_scrape_specs_module()
+    calls = []
+    sleeps = []
+
+    def fake_get(url: str, **kwargs):
+        calls.append((url, kwargs))
+        if len(calls) == 1:
+            raise httpx.ConnectError("Temporary failure in name resolution")
+        return _Response(
+            """
+            <html><body>
+              <a href="#" onclick="openApiGuide('lawInfoGuide')">법령</a>
+            </body></html>
+            """
+        )
+
+    monkeypatch.setattr(scrape_specs.httpx, "get", fake_get)
+    monkeypatch.setattr(scrape_specs.time, "sleep", sleeps.append)
+
+    guides = scrape_specs.get_all_guide_names(retries=2, retry_delay=0.01)
+
+    assert guides == [("lawInfoGuide", "법령")]
+    assert len(calls) == 2
+    assert sleeps == [0.01]
+
+
+def test_scrape_guide_retries_transient_post_failure(monkeypatch) -> None:
+    scrape_specs = _load_scrape_specs_module()
+    sleeps = []
+
+    class Client:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def post(self, url: str, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                raise httpx.ConnectError("Temporary failure in name resolution")
+            return _Response(
+                """
+                <html><body>
+                  <p>요청 URL https://open.law.go.kr/LSO/openApi/lawService.do?target=law</p>
+                </body></html>
+                """
+            )
+
+    client = Client()
+    monkeypatch.setattr(scrape_specs.time, "sleep", sleeps.append)
+
+    spec = scrape_specs.scrape_guide("lawInfoGuide", "법령", client, retries=2, retry_delay=0.01)
+
+    assert client.calls == 2
+    assert sleeps == [0.01]
+    assert spec["html_name"] == "lawInfoGuide"
+    assert spec["request_url"].startswith("https://open.law.go.kr/")
+
+
+def test_request_with_retries_retries_5xx_response(monkeypatch) -> None:
+    scrape_specs = _load_scrape_specs_module()
+    sleeps = []
+    responses = [_Response("server error", status_code=502), _Response("ok")]
+
+    monkeypatch.setattr(scrape_specs.time, "sleep", sleeps.append)
+
+    response = scrape_specs.request_with_retries(
+        lambda url: responses.pop(0),
+        "https://open.law.go.kr/test",
+        attempts=2,
+        retry_delay=0.01,
+    )
+
+    assert response.text == "ok"
+    assert sleeps == [0.01]


### PR DESCRIPTION
## Summary
- add retry/backoff around spec guide list and guide page scraping
- retry transient transport failures and 5xx responses
- add regression tests for DNS/connect retry and 5xx retry behavior

## Validation
- uv run ruff check .
- uv run mypy src
- uv run pytest -q

Closes #65